### PR TITLE
fix missing `setup.py` `long_description_content_type` argument for markdown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -172,6 +172,7 @@ setup(
     package_data={'ssw': SSWPY_FILES + SSWPY_TEST_FPS},
     description=ssw.DESCRIPTION,
     long_description=LONG_DESCRIPTION,
+    long_description_content_type='text/markdown',
     license=ssw.__license__,
     classifiers=CLASSIFIERS,
     setup_requires=['Cython', 'setuptools>=65.6.3'],

--- a/ssw/__init__.py
+++ b/ssw/__init__.py
@@ -35,7 +35,7 @@ __copyright__ = (
     'Harvard University'
 )
 __license__ = 'MIT'
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 DESCRIPTION = (
     'Python bindings for Complete-Striped-Smith-Waterman-Library '
     '(SSW) project'


### PR DESCRIPTION
version bump to 1.0.1